### PR TITLE
Remove trailing colon

### DIFF
--- a/resources/ui/HistoryEntry.js
+++ b/resources/ui/HistoryEntry.js
@@ -49,7 +49,7 @@ define([
                     connectId: [this.delegatedHistoryEntry],
                     label: "<span class=\"delegatedHistoryEntry\">"
                             + "<img class=\"userImage\" src=\"" + this.userImage + "\"></img>"
-                            + "<p>" + this.stateData.modifier + "<br> changed on " + this.formattedDate + ": </p>"
+                            + "<p>" + this.stateData.modifier + "<br> changed on " + this.formattedDate + "</p>"
                             + this.stateDelegate
                         + "</span>",
                     position: ["before", "after"]


### PR DESCRIPTION
Removes the trailing colon from the status history hover presentation.

![status history trailing colon](https://user-images.githubusercontent.com/20296116/51169322-e0b5dd00-18ab-11e9-8ece-e991a02fcc24.PNG)
